### PR TITLE
Drop distro validation for none-interactive CLI installation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -168,9 +168,6 @@ def run_cli(args=None):
         }
 
         distribution = PREFIX_TO_DISTRO.get(prefix)
-        if not distribution:
-            raise ValueError(f"Error: Invalid distribution prefix '{prefix}'.")
-            return
 
         repo_type = args.get("repository")
         if not repo_type or repo_type not in REPO_TYPES:

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ def parse_arguments(args=None):
     try:
         import argparse
         parser = argparse.ArgumentParser(description="Percona Installer Argument Parser")
-        parser.add_argument('-r', '--repository', type=str, help="main/testing/experimental")
+        parser.add_argument('-r', '--repository', type=str, help="release/testing/experimental")
         parser.add_argument('-p', '--product', type=str, help="ppg-17.0/ps-80/pxc-80/psmdb-80")
         parser.add_argument('-c', '--components', type=str, help="Comma-separated list of components")
         parser.add_argument('-s', '--solution', type=str, help="pg_tde_demo")


### PR DESCRIPTION
If we drop the distro validation for the none-interactive CLI, we add the possibility, to use and configure any repo from repo.percona.com. There is not limit anymore, what you can configure and setup